### PR TITLE
fix unsynchronized access to adapter->ps_state

### DIFF
--- a/rsi/rsi_91x_debugfs.c
+++ b/rsi/rsi_91x_debugfs.c
@@ -1044,6 +1044,7 @@ static ssize_t rsi_write_ps_params(struct file *file,
 	int total_bytes, cnt = 0;
 	int bytes_read = 0, t_bytes, ret = 0;
 	char *ps_param_buf = kmalloc(count + 1, GFP_KERNEL);
+	unsigned long flags;
 
 	if (!ps_param_buf)
 		return -ENOMEM;
@@ -1067,8 +1068,10 @@ static ssize_t rsi_write_ps_params(struct file *file,
 	kfree(ps_param_buf);
 	if (rsi_validate_ps_params(common, ps_params_vals))
 		return -EINVAL;
+	spin_lock_irqsave(&adapter->ps_lock, flags);
 	if (adapter->ps_state == PS_ENABLED)
 		rsi_enable_ps(adapter);
+	spin_unlock_irqrestore(&adapter->ps_lock, flags);
 	return total_bytes;
 }
 

--- a/rsi/rsi_91x_ps.c
+++ b/rsi/rsi_91x_ps.c
@@ -181,17 +181,22 @@ void rsi_conf_uapsd(struct rsi_hw *adapter)
 int rsi_handle_ps_confirm(struct rsi_hw *adapter, u8 *msg)
 {
 	u16 cfm_type = 0;
+	unsigned long flags;
 
 	cfm_type = *(u16 *)&msg[PS_CONFIRM_INDEX];
 
 	switch (cfm_type) {
 	case SLEEP_REQUEST:
+		spin_lock_irqsave(&adapter->ps_lock, flags);
 		if (adapter->ps_state == PS_ENABLE_REQ_SENT)
 			rsi_modify_ps_state(adapter, PS_ENABLED);
+		spin_unlock_irqrestore(&adapter->ps_lock, flags);
 		break;
 	case WAKEUP_REQUEST:
+		spin_lock_irqsave(&adapter->ps_lock, flags);
 		if (adapter->ps_state == PS_DISABLE_REQ_SENT)
 			rsi_modify_ps_state(adapter, PS_NONE);
+		spin_unlock_irqrestore(&adapter->ps_lock, flags);
 		break;
 	default:
 		rsi_dbg(ERR_ZONE,


### PR DESCRIPTION
Power save state (adapter->ps_state) was not fully protected from concurrent access.
Working on an embedded system with RS9116N module installed (SDIO connection is used) the following bug has been discovered:
1. rsi_disable_ps() is called,  PS request is sent (rsi_send_ps_request), but then sdio kernel thread gets executed
2. Confirmation from module received on sdio, rsi_handle_ps_confirm() called, but adapter->ps_state is still PS_NONE, so rsi_modify_ps_state() will not be called to modify ps_state
3. switched back to the context of rsi_disable_ps(), rsi_modify_ps_state changes ps_state to PS_DISABLE_REQ_SENT

As a result, we have module stuck in power save mode and ps_state = PS_DISABLE_REQ_SENT

