### PR TITLE
rsi_91x_mac80211: fix leak when crypto key disabled.

### DIFF
--- a/rsi/rsi_91x_mac80211.c
+++ b/rsi/rsi_91x_mac80211.c
@@ -1690,7 +1690,6 @@ static int rsi_mac80211_set_key(struct ieee80211_hw *hw,
 			memcpy(vif_info->rx_bcmc_pn_prev, vif_info->rx_bcmc_pn,
 				IEEE80211_CCMP_PN_LEN);
 		}
-		memset(key, 0, sizeof(struct ieee80211_key_conf));
 		memset(vif_info->rx_bcmc_pn, 0, IEEE80211_CCMP_PN_LEN);
 		vif_info->rx_pn_valid = false;
 		vif_info->key = NULL;


### PR DESCRIPTION
If the key information is cleared when the encryption key is DISABLE,
the information of the encryption method is not known in ieee80211_key_free_common(),
so the encryption key cannot be released and a leak occurs.

static void ieee80211_key_free_common(struct ieee80211_key *key)
{
	switch (key->conf.cipher) { <------
	case WLAN_CIPHER_SUITE_CCMP:
	case WLAN_CIPHER_SUITE_CCMP_256:
		ieee80211_aes_key_free(key->u.ccmp.tfm);
		break;
	case WLAN_CIPHER_SUITE_AES_CMAC:
	case WLAN_CIPHER_SUITE_BIP_CMAC_256:
		ieee80211_aes_cmac_key_free(key->u.aes_cmac.tfm);
		break;
	case WLAN_CIPHER_SUITE_BIP_GMAC_128:
	case WLAN_CIPHER_SUITE_BIP_GMAC_256:
		ieee80211_aes_gmac_key_free(key->u.aes_gmac.tfm);
		break;
	case WLAN_CIPHER_SUITE_GCMP:
	case WLAN_CIPHER_SUITE_GCMP_256:
		ieee80211_aes_gcm_key_free(key->u.gcmp.tfm);
		break;
	}
	kzfree(key);
}

Signed-off-by: Takeyoshi Kikuchi <kikuchi@centurysys.co.jp>