### PR TITLE
Fix leak when ULP sleep ack is sent

### DIFF
--- a/rsi/rsi_91x_mgmt.c
+++ b/rsi/rsi_91x_mgmt.c
@@ -3802,6 +3802,7 @@ int rsi_handle_card_ready(struct rsi_common *common, u8 *msg)
  */
 int rsi_send_ack_for_ulp_entry(struct rsi_common *common)
 {
+  int status;
   struct rsi_ulp_params *ulp_params;
   struct sk_buff *skb;
 
@@ -3815,7 +3816,9 @@ int rsi_send_ack_for_ulp_entry(struct rsi_common *common)
   ulp_params->desc_word[7] = cpu_to_le16(ULP_SLEEP_NOTIFY << 8);
   skb_put(skb, sizeof(struct rsi_ulp_params));
   common->ulp_sleep_ack_sent = true;
-  return common->priv->host_intf_ops->write_pkt(common->priv, skb->data, skb->len);
+  status = common->priv->host_intf_ops->write_pkt(common->priv, skb->data, skb->len);
+  dev_kfree_skb(skb);
+  return status;
 }
 EXPORT_SYMBOL_GPL(rsi_send_ack_for_ulp_entry);
 


### PR DESCRIPTION
An SKB buffer is allocated here to contain the
acknowledge to ULP sleep request but it is never freed.

This issue has been discovered with kmemleak reporting:

unreferenced object 0xbd931b40 (size 192):
	comm "SDIO-RX-Thread", pid 115, jiffies 4294939787 (age 385.370s)
	hex dump (first 32 bytes):
		00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
		00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
	backtrace:
		[<80128470>] kmem_cache_alloc+0x1c8/0x254
		[<8072c2d8>] __build_skb+0x34/0x9c
		[<8072c360>] build_skb+0x20/0x78
		[<8072c43c>] __alloc_rx_skb+0x84/0xf4
		[<8072c4d8>] __netdev_alloc_skb+0x2c/0x54
		[<7f04e290>] rsi_send_ack_for_ulp_entry+0x28/0xa0 [rsi_91x]
		[<7f052ad4>] rsi_mgmt_pkt_recv+0x4c0/0x10d0 [rsi_91x]
		[<7f049ed4>] rsi_read_pkt+0x104/0x268 [rsi_91x]
		[<7f070168>] rsi_sdio_rx_thread+0xa8/0x180 [rsi_sdio]
		[<8005065c>] kthread+0xec/0x104
		[<800107e8>] ret_from_fork+0x14/0x2c
		[<ffffffff>] 0xffffffff

In order to reproduce it just load the module and wait,
you will see the memory usage increasing rapidly.

Signed-off-by: Stefano Manni <stefano.manni@eletechsrl.it>